### PR TITLE
feature_total_textures_gpu_size

### DIFF
--- a/app_web/src/logic/uimodel.js
+++ b/app_web/src/logic/uimodel.js
@@ -497,7 +497,7 @@ class UIModel
         statisticsUpdateObservable.subscribe(
             data => {
                 let compressionStatistics = {};
-                compressionStatistics["Before"] = data.texturesSize.toFixed(2) + " mb";
+                compressionStatistics["Before"] = ["- DiskSize: " + data.texturesSize.toFixed(2) + " mb", "- GpuSize: " + data.texturesGpuSize.toFixed(2) + " mb"];
                 compressionStatistics["After"] = "";
                 this.app.compressionStatistics = compressionStatistics;
                 this.app.texturesStatistics = data.textures;
@@ -544,7 +544,7 @@ class UIModel
         statisticsUpdateObservable.subscribe(
             data => {
                 let done = data.textures.some(texture => texture.isCompleted);
-                this.app.compressionStatistics["After"] = done ? (data.texturesSize.toFixed(2) + " mb") : "";
+                this.app.compressionStatistics["After"] = done ? ["- DiskSize: " + data.texturesSize.toFixed(2) + " mb", "- GpuSize: " + data.texturesGpuSize.toFixed(2) + " mb"] : "";
                 this.app.texturesStatistics = data.textures;
                 this.app.compressionCompleted = done;
                 this.app.compressedKTX |= this.app.selectedCompressionType === "KTX2";

--- a/source/GltfView/gltf_view.js
+++ b/source/GltfView/gltf_view.js
@@ -192,7 +192,8 @@ class GltfView
         {
             return {
                 textures: [],
-                texturesSize: 0
+                texturesSize: 0,
+                texturesGpuSize: 0
             };
         }
 
@@ -252,6 +253,7 @@ class GltfView
         const toMb = (value) => { return value/1024/1024; };
         
         var texturesFileSize = 0;
+        var texturesFileGpuSize = 0;
         const textures = [];
         const activeTextures = state.gltf.images;
         activeTextures.forEach(element => {
@@ -286,12 +288,14 @@ class GltfView
             if(element.mimeType !== ImageMimeType.GLTEXTURE)
                 textures.push(texture);
             texturesFileSize += fileSize;
+            texturesFileGpuSize += toMb(element.gpuSize);
         });
 
         // assemble statistics object
         return {
             textures: textures,
-            texturesSize: texturesFileSize
+            texturesSize: texturesFileSize,
+            texturesGpuSize: texturesFileGpuSize
         };
     }
 
@@ -313,13 +317,15 @@ class GltfView
         {
             return {
                 textures: [],
-                texturesSize: 0
+                texturesSize: 0,
+                texturesGpuSize: 0
             };
         }
 
         const toMb = (value) => { return value/1024/1024; };
 
         var texturesFileSize = 0;
+        var textureGPUSize = 0;
         const textures = [];
         const activeTextures = state.gltf.images;
         const activeSelectedTextures = state.compressorParameters.processedImages.map(index => activeTextures[index]);
@@ -373,12 +379,15 @@ class GltfView
             if(element.mimeType !== ImageMimeType.GLTEXTURE)
                 textures.push(texture);
             texturesFileSize += isIncluded ? fileSizeCompressed : fileSize;
+            textureGPUSize += isIncluded ? toMb(element.compressedGpuSize) : toMb(element.gpuSize);
+            
         });
 
         // assemble statistics object
         return {
             textures: textures,
-            texturesSize: texturesFileSize
+            texturesSize: texturesFileSize,
+            texturesGpuSize: textureGPUSize
         };
     }
 


### PR DESCRIPTION
Thanks for create this amazing tool (=

I added info about total textures vram size before and after compression. 

<img width="297" alt="image" src="https://github.com/KhronosGroup/glTF-Compressor/assets/17799857/bfd444d6-030f-4b81-bfab-b9944a1e7b4d">